### PR TITLE
add bare-bones service worker for offline support

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <title>Crosswordle</title>
     <link rel="stylesheet" href="style/style.css">
+    <script src="src/index.js"></script>
     <script src="src/puzzles.js"></script>
     <script src="src/game.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('sw.js');
+  });
+} else {
+  console.log('serviceWorker not supported.');
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,6 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.2.0/workbox-sw.js');
+
+workbox.routing.registerRoute(
+  () => true,
+  new workbox.strategies.NetworkFirst()
+);


### PR DESCRIPTION
Add a [Network First](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache) service worker to enable offline mode (fixes https://github.com/flackr/crosswordle/issues/18).

Network First _should_ be the safest, I believe, in that users will never see stale content as long as they have a network connection.

If that's not the most important thing, then something like [Stale-While-Revalidate](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#stale-while-revalidate) may help speed up page load on slow network.

This PR uses the [workbox CDN](https://developers.google.com/web/tools/workbox/modules/workbox-sw), but you could also look into [generating a full SW](https://developers.google.com/web/tools/workbox/guides/generate-service-worker/cli) to host with the rest of your project.

You can test out this PR at https://glennhartmann.github.io/crosswordle/.